### PR TITLE
Added lightweight model support -> MLPMultiClass plugin

### DIFF
--- a/dialogy/constants/__init__.py
+++ b/dialogy/constants/__init__.py
@@ -105,7 +105,7 @@ DATA = "data"
 CLASSIFICATION_INPUT = "classification_input"
 XLMR_MODULE = "simpletransformers.classification"
 XLMR_MULTI_CLASS_MODEL = "ClassificationModel"
-XLMR_MODEL = "xlmroberta" 
+XLMR_MODEL = "xlmroberta"
 XLMR_MODEL_TIER = "xlm-roberta-base"
 INTENT = "intent"
 INTENTS = f"{INTENT}s"
@@ -114,6 +114,27 @@ ENTITIES = "entities"
 SCORE = "score"
 LABELENCODER_FILE = "labelencoder.pkl"
 INVALID_TOKENS = ["<UNK>", "<PAD>", "<SOS>", "<EOS>"]
+
+# MLP
+MLPMODEL_FILE = "mlpmodelpipeline.joblib"
+NUM_TRAIN_EPOCHS = "num_train_epochs"
+MLP_DEFAULT_TRAIN_EPOCHS = 25
+DEFAULT_NGRAM = (1, 1)
+TFIDF_LOWERCASE = False
+STOPWORDS = None
+MLP_RANDOMSTATE = 1
+
+TFIDF = "tfidf"
+MLP = "mlp"
+
+# Hyperparams For MLP
+USE_GRIDSEARCH = "gridsearch_hyperparams"
+PARAMS = "params"
+GRID_SCORETYPE = "weighted"
+CV = "cv"
+VERBOSE_LEVEL = "verbose_level"
+NGRAM_RANGE = "ngram_range"
+GRIDSEARCH_WORKERS = -1  # -1 means use all available cores
 
 # CLI Commands
 TRAIN = "train"

--- a/dialogy/plugins/__init__.py
+++ b/dialogy/plugins/__init__.py
@@ -1,6 +1,7 @@
 from dialogy.plugins.text.calibration.xgb import CalibrationModel
 from dialogy.plugins.text.canonicalization import CanonicalizationPlugin
 from dialogy.plugins.text.classification.xlmr import XLMRMultiClass
+from dialogy.plugins.text.classification.mlp import MLPMultiClass
 from dialogy.plugins.text.duckling_plugin import DucklingPlugin
 from dialogy.plugins.text.lb_plugin import DucklingPluginLB
 from dialogy.plugins.text.list_entity_plugin import ListEntityPlugin

--- a/dialogy/plugins/text/classification/mlp.py
+++ b/dialogy/plugins/text/classification/mlp.py
@@ -80,13 +80,13 @@ class MLPMultiClass(Plugin):
                 "Ignore this message if you are training but if you are using this in production or testing, then this is serious!"
             )
 
-    def init_model(self) -> None:
+    def init_model(self) -> Dict[str, Any]:
         """
         Initialize the model if artifacts are available.
         """
         if os.path.exists(self.mlp_model_path):
             self.load()
-            return
+            return {}
         args = (
             self.args_map[self.purpose]
             if self.args_map and self.purpose in self.args_map
@@ -133,15 +133,14 @@ class MLPMultiClass(Plugin):
 
         return args
 
-    def get_gridsearch_grid(self, **kwargs) -> List[Dict[str, Any]]:
+    def get_gridsearch_grid(self, **kwargs: Any) -> List[Dict[str, List[Any]]]:
         """
         Gets gridsearch hyperparameters for the model in proper grid params format.
 
         Raises:
             ValueError: If a gridsearch parameter doesn't exist in sklearns TFIDF and MLPClassifier modules.
         """
-
-        grid_params: Dict[str, Any] = {}
+        grid_params: Dict[str, List[Any]] = {}
         for k, v in kwargs.items():
             if (
                 k not in self.model_pipeline[const.TFIDF].get_params().keys()

--- a/dialogy/plugins/text/classification/tokenizers.py
+++ b/dialogy/plugins/text/classification/tokenizers.py
@@ -1,2 +1,2 @@
-def identity_tokenizer(text):
+def identity_tokenizer(text: str) -> str:
     return text

--- a/dialogy/plugins/text/classification/tokenizers.py
+++ b/dialogy/plugins/text/classification/tokenizers.py
@@ -1,0 +1,2 @@
+def identity_tokenizer(text):
+    return text

--- a/tests/plugin/text/classification/test_mlp.py
+++ b/tests/plugin/text/classification/test_mlp.py
@@ -276,7 +276,6 @@ def test_invalid_operations():
     assert mlp_clf.inference([])[0].name == "_error_"
 
     mlp_clf.model_pipeline = None
-    # with pytest.raises(AttributeError):
     assert mlp_clf.inference(["text"])[0].name == "_error_"
 
     if os.path.exists(file_path):
@@ -285,11 +284,6 @@ def test_invalid_operations():
 
 @pytest.mark.parametrize("payload", load_tests("mlp_cases", __file__))
 def test_inference(payload):
-    # save_module_name = const.XLMR_MODULE
-    # save_model_name = const.XLMR_MULTI_CLASS_MODEL
-    # const.XLMR_MODULE = "tests.plugin.text.classification.test_xlmr"
-    # const.XLMR_MULTI_CLASS_MODEL = "MockClassifier"
-
     directory = "/tmp"
     file_path = os.path.join(directory, const.MLPMODEL_FILE)
     if os.path.exists(file_path):

--- a/tests/plugin/text/classification/test_mlp.py
+++ b/tests/plugin/text/classification/test_mlp.py
@@ -1,0 +1,370 @@
+import json
+import os
+import tempfile
+from typing import List
+
+import pandas as pd
+import pytest
+import sklearn
+import joblib
+
+import dialogy.constants as const
+from dialogy.plugins import MergeASROutputPlugin, MLPMultiClass
+from dialogy.utils import load_file
+from dialogy.workflow import Workflow
+from tests import load_tests
+
+
+class MockMLPClassifier:
+    def __init__(self, model_dir, args=None, **kwargs):
+        self.model_dir = model_dir
+        self.args = args or {}
+        self.kwargs = kwargs
+        if not os.path.isdir(self.model_dir):
+            raise OSError("No such directory")
+
+    def inference(self, texts: List[str]):
+        return
+
+    def train(self, training_data: pd.DataFrame):
+        return
+
+
+def write_intent_to_workflow(w, v):
+    w.output[const.INTENTS] = v
+
+
+def update_input(w, v):
+    w.input[const.CLASSIFICATION_INPUT] = v
+
+
+def test_mlp_plugin_when_no_mlpmodel_saved():
+    mlp_clf = MLPMultiClass(
+        model_dir=".",
+        access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+        mutate=write_intent_to_workflow,
+    )
+    assert isinstance(mlp_clf, MLPMultiClass)
+    assert mlp_clf.model_pipeline is None
+
+
+def test_mlp_plugin_when_mlpmodel_EOFError(capsys):
+    _, file_path = tempfile.mkstemp(suffix=".pkl")
+    save_mlp_model_file = const.MLPMODEL_FILE
+    directory, file_name = os.path.split(file_path)
+    const.MLPMODEL_FILE = file_name
+    with capsys.disabled():
+        mlp_plugin = MLPMultiClass(
+            model_dir=directory,
+            access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+            mutate=write_intent_to_workflow,
+            debug=True,
+        )
+        assert mlp_plugin.model_pipeline is None
+    os.remove(file_path)
+    const.MLPMODEL_FILE = save_mlp_model_file
+
+
+def test_mlp_init_mock():
+    mlp_clf = MLPMultiClass(
+        model_dir=".",
+        access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+        mutate=write_intent_to_workflow,
+    )
+    mlp_clf.init_model()
+    assert isinstance(mlp_clf.model_pipeline, sklearn.pipeline.Pipeline)
+
+
+def test_mlp_invalid_argsmap():
+    with pytest.raises(ValueError):
+        MLPMultiClass(
+            model_dir=".",
+            access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+            mutate=write_intent_to_workflow,
+            args_map={"invalid": "value"},
+        )
+
+
+def test_mlp_gridsearch_argsmap():
+    USE = "use"
+    fake_args = {
+        const.TRAIN: {
+            const.NUM_TRAIN_EPOCHS: 10,
+            const.USE_GRIDSEARCH: {
+                USE: True,
+                const.CV: 2,
+                const.VERBOSE_LEVEL: 2,
+                const.PARAMS: {
+                    "activation": ["relu", "sigmoid"],
+                    "hidden_layer_sizes": [(10,), (10, 10), (10, 10, 10)],
+                    "ngram_range": [(1, 1), (1, 2), (2, 2)],
+                    "max_iter": [10, 100, 1000],
+                },
+            },
+        },
+        const.TEST: {},
+        const.PRODUCTION: {},
+    }
+
+    xlmr_clf = MLPMultiClass(
+        model_dir=".",
+        access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+        mutate=write_intent_to_workflow,
+        args_map=fake_args,
+    )
+    xlmr_clf.init_model()
+    assert isinstance(xlmr_clf.model_pipeline, sklearn.model_selection.GridSearchCV)
+
+    fake_invalid_args = {
+        const.TRAIN: {
+            const.NUM_TRAIN_EPOCHS: 10,
+            const.USE_GRIDSEARCH: {
+                USE: True,
+                const.CV: 2,
+                const.VERBOSE_LEVEL: 2,
+                const.PARAMS: {
+                    "activation": ["relu", "sigmoid"],
+                    "hidden_layer_sizes": [(10,), (10, 10), (10, 10, 10)],
+                    "ngram_range": [(1, 1), (1, 2), (2, 2)],
+                    "iterations": [10, 100, 1000],
+                },
+            },
+        },
+        const.TEST: {},
+        const.PRODUCTION: {},
+    }
+
+    with pytest.raises(ValueError):
+        xlmr_clf_invalid = MLPMultiClass(
+            model_dir=".",
+            access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+            mutate=write_intent_to_workflow,
+            args_map=fake_invalid_args,
+        )
+        xlmr_clf_invalid.init_model()
+
+
+def test_train_mlp_mock():
+    directory = "/tmp"
+    file_path = os.path.join(directory, const.MLPMODEL_FILE)
+
+    mlp_clf = MLPMultiClass(
+        model_dir=directory,
+        access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+        mutate=write_intent_to_workflow,
+    )
+
+    train_df = pd.DataFrame(
+        [
+            {"data": "yes", "labels": "_confirm_"},
+            {"data": "yea", "labels": "_confirm_"},
+            {"data": "no", "labels": "_cancel_"},
+            {"data": "nope", "labels": "_cancel_"},
+        ]
+    )
+
+    mlp_clf.train(train_df)
+    assert mlp_clf.labels_num == 2
+
+    # This copy loads from the same directory that was trained previously.
+    # So this instance would have read the saved mlp model.
+    mlp_clf_copy = MLPMultiClass(
+        model_dir=directory,
+        access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+        mutate=write_intent_to_workflow,
+    )
+    mlp_clf_copy.load()
+    assert isinstance(mlp_clf_copy.model_pipeline, sklearn.pipeline.Pipeline)
+    assert mlp_clf_copy.valid_mlpmodel is True
+    os.remove(file_path)
+
+
+def test_train_mlp_gridsearch_mock():
+    directory = "/tmp"
+    file_path = os.path.join(directory, const.MLPMODEL_FILE)
+    USE = "use"
+    fake_args = {
+        const.TRAIN: {
+            const.NUM_TRAIN_EPOCHS: 10,
+            const.USE_GRIDSEARCH: {
+                USE: True,
+                const.CV: 2,
+                const.VERBOSE_LEVEL: 2,
+                const.PARAMS: {
+                    "activation": ["relu", "tanh"],
+                    "hidden_layer_sizes": [(1,), (2, 1)],
+                    "ngram_range": [(1, 1)],
+                    "max_iter": [1, 2],
+                },
+            },
+        },
+        const.TEST: {},
+        const.PRODUCTION: {},
+    }
+
+    mlp_clf = MLPMultiClass(
+        model_dir=directory,
+        access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+        mutate=write_intent_to_workflow,
+        args_map=fake_args,
+    )
+
+    train_df = pd.DataFrame(
+        [
+            {"data": "yes", "labels": "_confirm_"},
+            {"data": "yea", "labels": "_confirm_"},
+            {"data": "no", "labels": "_cancel_"},
+            {"data": "nope", "labels": "_cancel_"},
+        ]
+    )
+
+    mlp_clf.train(train_df)
+    assert mlp_clf.labels_num == 2
+
+    # This copy loads from the same directory that was trained previously.
+    # So this instance would have read the saved mlp model.
+    mlp_clf_copy = MLPMultiClass(
+        model_dir=directory,
+        access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+        mutate=write_intent_to_workflow,
+    )
+    mlp_clf_copy.load()
+    assert mlp_clf_copy.valid_mlpmodel is True
+    mlp_clf_copy.train(train_df)  # When trying to train an already trained model
+    os.remove(file_path)
+
+
+def test_invalid_operations():
+    directory = "/tmp"
+    file_path = os.path.join(directory, const.MLPMODEL_FILE)
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+    mlp_clf = MLPMultiClass(
+        model_dir=directory,
+        access=lambda w: w.input[const.CLASSIFICATION_INPUT],
+        mutate=write_intent_to_workflow,
+    )
+    mlp_clf.init_model()
+
+    train_df_empty = pd.DataFrame()
+    train_df_invalid = pd.DataFrame(
+        [
+            {"apples": "yes", "fruit": "fruit"},
+            {"apples": "yea", "fruit": "fruit"},
+            {"apples": "no", "fruit": "fruit"},
+            {"apples": "nope", "fruit": "fruit"},
+        ]
+    )
+    assert mlp_clf.validate(train_df_empty) is False
+
+    mlp_clf.train(train_df_empty)
+    assert load_file(file_path, mode="rb", loader=joblib.load) is None
+    assert mlp_clf.validate(train_df_invalid) is False
+
+    mlp_clf.train(train_df_invalid)
+    assert load_file(file_path, mode="rb", loader=joblib.load) is None
+    assert mlp_clf.inference(["text"])[0].name == "_error_"
+
+    with pytest.raises(ValueError):
+        mlp_clf.save()
+
+    mlp_clf.model_pipeline = MockMLPClassifier(directory)
+    with pytest.raises(AttributeError):
+        mlp_clf.inference(["text"])
+
+    assert mlp_clf.inference([])[0].name == "_error_"
+
+    mlp_clf.model_pipeline = None
+    # with pytest.raises(AttributeError):
+    assert mlp_clf.inference(["text"])[0].name == "_error_"
+
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+
+@pytest.mark.parametrize("payload", load_tests("mlp_cases", __file__))
+def test_inference(payload):
+    # save_module_name = const.XLMR_MODULE
+    # save_model_name = const.XLMR_MULTI_CLASS_MODEL
+    # const.XLMR_MODULE = "tests.plugin.text.classification.test_xlmr"
+    # const.XLMR_MULTI_CLASS_MODEL = "MockClassifier"
+
+    directory = "/tmp"
+    file_path = os.path.join(directory, const.MLPMODEL_FILE)
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+    USE = "use"
+    fake_args = {
+        const.TRAIN: {
+            const.NUM_TRAIN_EPOCHS: 5,
+            const.USE_GRIDSEARCH: {
+                USE: False,
+                const.CV: 2,
+                const.VERBOSE_LEVEL: 2,
+                const.PARAMS: {
+                    "activation": ["relu", "tanh"],
+                    "hidden_layer_sizes": [(10,), (2, 2)],
+                    "ngram_range": [(1, 1), (1, 2)],
+                    "max_iter": [20, 2],
+                },
+            },
+        },
+        const.TEST: {},
+        const.PRODUCTION: {},
+    }
+
+    text = payload.get("input")
+    intent = payload["expected"]["label"]
+
+    mlp_clf = MLPMultiClass(
+        model_dir=directory,
+        access=lambda w: (w.input[const.CLASSIFICATION_INPUT],),
+        mutate=write_intent_to_workflow,
+        args_map=fake_args,
+        debug=True,
+    )
+
+    merge_asr_output_plugin = MergeASROutputPlugin(
+        access=lambda w: (w.input[const.CLASSIFICATION_INPUT],),
+        mutate=update_input,
+    )
+
+    workflow = Workflow([merge_asr_output_plugin, mlp_clf])
+
+    train_df = pd.DataFrame(
+        [
+            {
+                "data": json.dumps([[{"transcript": "yes"}]]),
+                "labels": "_confirm_",
+            },
+            {
+                "data": json.dumps([[{"transcript": "ye"}]]),
+                "labels": "_confirm_",
+            },
+            {
+                "data": json.dumps([[{"transcript": "<s> yes </s> <s> ye </s>"}]]),
+                "labels": "_confirm_",
+            },
+            {
+                "data": json.dumps([[{"transcript": "no"}]]),
+                "labels": "_cancel_",
+            },
+            {
+                "data": json.dumps([[{"transcript": "new"}]]),
+                "labels": "_cancel_",
+            },
+            {
+                "data": json.dumps([[{"transcript": "<s> new </s> <s> no </s>"}]]),
+                "labels": "_cancel_",
+            },
+        ]
+    )
+
+    workflow.train(train_df)
+    output = workflow.run(input_={const.CLASSIFICATION_INPUT: text})
+    assert output[const.INTENTS][0].name == intent
+    assert output[const.INTENTS][0].score > 0.5
+    if os.path.exists(file_path):
+        os.remove(file_path)

--- a/tests/plugin/text/classification/test_mlp_cases.yaml
+++ b/tests/plugin/text/classification/test_mlp_cases.yaml
@@ -1,0 +1,30 @@
+- input:
+    - "yes"
+  expected:
+    label: "_confirm_"
+    scores: 1
+
+- input:
+    - "no"
+  expected:
+    label: "_cancel_"
+    scores: 1
+
+- input:
+    - "yes"
+    - "ye"
+  expected:
+    label: "_confirm_"
+    scores: 1
+
+- input:
+    - "new"
+    - "no"
+  expected:
+    label: "_cancel_"
+    scores: 1
+
+- input: []
+  expected:
+    label: "_error_"
+    scores: 1


### PR DESCRIPTION


- can be used in exact same way as XLMRMultiClass plugin.
- uses sklearn [tfidf](https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.TfidfVectorizer.html) + [MLP](https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPClassifier.html) classifier.
- added [hyperparameter tuning](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html) support for it.
- can be tweaked from [dialogy template config](https://github.com/skit-ai/dialogy-template-simple-transformers/blob/main/slu/config/config.yaml.jinja) itself.
- added tests

> this model works best when your dataset has high structured noise + high datapoints

on more info regarding how it performs compared to xlmr + edge cases -> [read this](https://docs.google.com/document/d/1HqxrrticePnN34414TWOOcxuFDBRR-lHUtTQIKHLXcY/edit?usp=sharing)

more improvements coming in future.