### PR TITLE
add: gets all predicted intent classes + respective confidence scores

### DIFF
--- a/dialogy/plugins/text/classification/mlp.py
+++ b/dialogy/plugins/text/classification/mlp.py
@@ -221,8 +221,6 @@ class MLPMultiClass(Plugin):
 
         return [
             Intent(name=intent, score=round(score, self.round)).add_parser(self)
-            if score > self.threshold
-            else fallback_output
             for score, intent in probs_and_classes
         ]
 

--- a/dialogy/plugins/text/classification/xlmr.py
+++ b/dialogy/plugins/text/classification/xlmr.py
@@ -160,15 +160,17 @@ class XLMRMultiClass(Plugin):
         predictions, logits = self.model.predict(texts)
         if not predictions:
             return [fallback_output]
-
-        confidence_list = [max(np.exp(logit) / sum(np.exp(logit))) for logit in logits]
-        predicted_intents = self.labelencoder.inverse_transform(predictions)
+        
+        confidence_scores = [np.exp(logit) / sum(np.exp(logit)) for logit in logits]
+        intents_confidence_order = np.argsort(confidence_scores)[0][::-1]
+        predicted_intents = self.labelencoder.inverse_transform(intents_confidence_order)
+        ordered_confidence_scores = [confidence_scores[0][idx] for idx in intents_confidence_order]
 
         return [
-            Intent(name=intent, score=round(score, self.round)).add_parser(self)
-            if score > self.threshold
-            else fallback_output
-            for intent, score in zip(predicted_intents, confidence_list)
+            Intent(name=intent, score=round(score, self.round)).add_parser(
+                self.__class__.__name__
+            )
+            for intent, score in zip(predicted_intents, ordered_confidence_scores)
         ]
 
     def validate(self, training_data: pd.DataFrame) -> bool:


### PR DESCRIPTION
 xlmr and mlp plugin returns all predicted intent classes + confidence scores in order, 
 doesn't return fallback label when intent scores less than given threshold anymore.
 This has to be handled from [slu-template](https://github.com/skit-ai/dialogy-template-simple-transformers) side.