### PR TITLE
state input to be passed as string, not list inside XLMR inference.

### DIFF
--- a/dialogy/plugins/text/classification/xlmr.py
+++ b/dialogy/plugins/text/classification/xlmr.py
@@ -148,14 +148,14 @@ class XLMRMultiClass(Plugin):
         return hasattr(self.labelencoder, "classes_")
 
     def inference(
-        self, texts: Optional[List[str]], state: Optional[List[str]] = None
+        self, texts: Optional[List[str]], state: Optional[str] = None
     ) -> List[Intent]:
         """
         Predict the intent of a list of texts.
         If the model has been trained using the state features, it expects the text to also be appended with the state token else the predictions would be spurious.
 
         :param texts: A list of strings, derived from ASR transcripts.
-        :param state: A list of states, mapped to the ASR transcripts.
+        :param state: state, mapped to the ASR transcripts.
         :type texts: List[str]
         :type state: List[str]
         :raises AttributeError: In case the labelencoder is not available.
@@ -177,8 +177,7 @@ class XLMRMultiClass(Plugin):
                 f"Plugin {self.__class__.__name__} requires state to be passed to the model."
             )
         elif self.use_state and state:
-            assert len(texts) == len(state)
-            texts = [f"{text} <s> {state} </s>" for state, text in zip(state, texts)]
+            texts = [f"{text} <s> {state} </s>" for text in texts]
         if not self.valid_labelencoder:
             raise AttributeError(
                 "Seems like you forgot to "
@@ -295,4 +294,4 @@ class XLMRMultiClass(Plugin):
         )
 
     def utility(self, input: Input, _: Output) -> List[Intent]:
-        return self.inference(input.clf_feature)
+        return self.inference(input.clf_feature, input.current_state)


### PR DESCRIPTION
1) state input to be passed as a string, not list inside XLMR inference from self.utility.