### PR TITLE
Fix/#148/duckling invalid dt iso

### DIFF
--- a/dialogy/plugins/text/duckling_plugin/__init__.py
+++ b/dialogy/plugins/text/duckling_plugin/__init__.py
@@ -793,7 +793,7 @@ class DucklingPlugin(EntityScoringMixin, Plugin):
                 duration_cast_operator=duration_cast_operator,
                 constraints=self.constraints,
             )
-            if entity.value:
+            if entity and entity.value:
                 entity.add_parser(self)
                 deserialized_entities.append(entity)
         return deserialized_entities

--- a/dialogy/types/entity/base_entity/__init__.py
+++ b/dialogy/types/entity/base_entity/__init__.py
@@ -249,7 +249,7 @@ class BaseEntity:
     @classmethod
     def from_duckling(
         cls, d: Dict[str, Any], alternative_index: int, **kwargs: Any
-    ) -> BaseEntity:
+    ) -> Optional[BaseEntity]:
         raise NotImplementedError  # pragma: no cover
 
 

--- a/dialogy/types/entity/deserialize/__init__.py
+++ b/dialogy/types/entity/deserialize/__init__.py
@@ -57,7 +57,7 @@ class EntityDeserializer:
         timezone: str = "UTC",
         duration_cast_operator: Optional[str] = None,
         constraints: Optional[Dict[str, Any]] = None,
-    ) -> BaseEntity:
+    ) -> Optional[BaseEntity]:
         cls.validate(duckling_entity_dict)
         entity_class_name = cls.get_entity_class_str(duckling_entity_dict)
         EntityClass: BaseEntity = cls.entitiy_classes[entity_class_name]

--- a/dialogy/types/entity/time/__init__.py
+++ b/dialogy/types/entity/time/__init__.py
@@ -62,6 +62,13 @@ from dialogy.types.entity.base_entity import BaseEntity
 from dialogy.types.entity.deserialize import EntityDeserializer
 
 
+def dt_from_isoformat(iso_datetime: str) -> datetime:
+    """
+    Converts an ISO-formatted datetime string to a datetime object.
+    """
+    return datetime.fromisoformat(iso_datetime)
+
+
 @EntityDeserializer.register(const.TIME)
 @attr.s
 class TimeEntity(BaseEntity):
@@ -103,7 +110,7 @@ class TimeEntity(BaseEntity):
         :rtype: Optional[datetime]
         """
         entity_date_value = super().get_value()
-        return datetime.fromisoformat(entity_date_value)
+        return dt_from_isoformat(entity_date_value)
 
     def collect_datetime_values(self) -> List[datetime]:
         """
@@ -112,7 +119,7 @@ class TimeEntity(BaseEntity):
         :return: List of datetime values
         :rtype: List[str]
         """
-        return [datetime.fromisoformat(value[const.VALUE]) for value in self.values]
+        return [dt_from_isoformat(value[const.VALUE]) for value in self.values]
 
     def is_uniq_date_from_values(self) -> bool:
         """
@@ -231,7 +238,7 @@ class TimeEntity(BaseEntity):
 
         constrained_d_values = []
         for datetime_val in d_values:
-            datetime_ = datetime.fromisoformat(datetime_val[const.VALUE])
+            datetime_ = dt_from_isoformat(datetime_val[const.VALUE])
             if cls.apply_constraint(datetime_, constraint):
                 constrained_d_values.append(datetime_val)
         return constrained_d_values
@@ -243,7 +250,7 @@ class TimeEntity(BaseEntity):
         alternative_index: int,
         constraints: Optional[Dict[str, Any]] = None,
         **kwargs: Any
-    ) -> TimeEntity:
+    ) -> Optional[TimeEntity]:
         datetime_values = d[const.VALUE][const.VALUES]
         grain = datetime_values[0][const.GRAIN]
 

--- a/dialogy/types/entity/time/__init__.py
+++ b/dialogy/types/entity/time/__init__.py
@@ -270,5 +270,11 @@ class TimeEntity(BaseEntity):
             values=datetime_values,
             grain=grain,
         )
+
+        try:
+            time_entity.collect_datetime_values()
+        except ValueError:
+            return None
+
         time_entity.set_entity_type()
         return time_entity

--- a/tests/plugin/text/test_duckling_plugin/test_cases.yaml
+++ b/tests/plugin/text/test_duckling_plugin/test_cases.yaml
@@ -133,6 +133,33 @@
   'latent': False}]
   expected: [{"entity_type": "date"}]
 
+- description: "test time entity with value over 10k."
+  input: "10000"
+  duckling:
+    dimensions: ["time"]
+    locale: "en_IN"
+    timezone: "Asia/Kolkata"
+  mock_entity_json: [{
+    "body": "10000",
+    "start": 0,
+    "value": {
+      "values": [
+        {
+          "value": "10000-01-01T00:00:00.000+00:00",
+          "grain": "year",
+          "type": "value"
+        }
+      ],
+      "value": "10000-01-01T00:00:00.000+00:00",
+      "grain": "year",
+      "type": "value"
+    },
+    "end": 5,
+    "dim": "time",
+    "latent": true
+  }]
+  expected: []
+
 - description: "test time interval."
   input: "between 2 to 4 am"
   duckling:


### PR DESCRIPTION
#148 

We try to solve the invalid datetimes by allowing our parsers to evaluate entities before returning them.

```python

try:
    time_entity.collect_datetime_values()
except ValueError:
    return None
```
This within an entity ensures that if we can parse the values only then the entity would be produced. In response to this, we have also changed the type signature of methods.
