### PR TITLE
slot.json() should return items in a descending order

### DIFF
--- a/dialogy/types/slots/__init__.py
+++ b/dialogy/types/slots/__init__.py
@@ -48,6 +48,11 @@ class Slot:
         Returns:
             Dict[str, Any]
         """
+        self.values = sorted(
+            self.values,
+            key=lambda parse: parse.score or 0,
+            reverse=True,
+        )
         return {
             "name": self.name,
             "types": self.types,

--- a/dialogy/workflow/workflow.py
+++ b/dialogy/workflow/workflow.py
@@ -194,7 +194,7 @@ class Workflow:
         self.input = None
         self.output = Output()
 
-    def set(self, path: str, value: Any, replace: bool = False) -> Workflow:
+    def set(self, path: str, value: Any, replace: bool = False, sort_output_attributes: bool = True) -> Workflow:
         """
         Set attribute path with value.
 
@@ -205,6 +205,8 @@ class Workflow:
         :type path: str
         :param value: A value to set.
         :type value: Any
+        :param sort_output_attributes: A boolean to sort output attributes.
+        :type value: bool
         :return: This instance
         :rtype: Workflow
         """
@@ -215,12 +217,14 @@ class Workflow:
         elif attribute in const.OUTPUT_ATTRIBUTES and isinstance(value, (list, dict)):
             if not replace and isinstance(value, list):
                 previous_value = self.output.intents if attribute == const.INTENTS else self.output.entities  # type: ignore
-
-                value = sorted(
-                    previous_value + value,
-                    key=lambda parse: parse.score or 0,
-                    reverse=True,
-                )
+                if sort_output_attributes:
+                    value = sorted(
+                        previous_value + value,
+                        key=lambda parse: parse.score or 0,
+                        reverse=True,
+                    )
+                else:
+                    value = previous_value + value
 
             self.output = Output.from_dict({attribute: value}, reference=self.output)
 

--- a/tests/plugin/text/slot_filler/test_rule_slot_filler.py
+++ b/tests/plugin/text/slot_filler/test_rule_slot_filler.py
@@ -325,3 +325,58 @@ def test_slot_competition_fill_one() -> None:
     # The `entity_1_slot` and `entity_2_slot` are filled.
 
     assert "entity_1_slot" not in output[const.INTENTS][0]["slots"]
+
+def test_slot_filling_order() -> None:
+    """
+    Here, we will see that entities of same type filled in a slot are sorted by their score in descending order.
+    """
+    intent_name = "intent_1"
+
+    # Setting up the slot-filler, both instantiation and plugin is created. (notice two calls).
+    slot_filler = RuleBasedSlotFillerPlugin(
+        rules=rules, dest="output.intents", fill_multiple=True
+    )
+
+    # Create a mock `workflow`
+    workflow = Workflow([slot_filler])
+
+    # ... a mock `Intent`
+    intent = Intent(name=intent_name, score=0.8)
+
+    # Here we have three entities which have different scores.
+    body = "12th december"
+    entity_1 = BaseEntity(
+        range={"from": 0, "to": len(body)},
+        body=body,
+        dim="default",
+        score=0.2,
+        entity_type="entity_1",
+        values=[{"value": "value_1"}],
+    )
+
+    entity_2 = BaseEntity(
+        range={"from": 0, "to": len(body)},
+        body=body,
+        dim="default",
+        score=0.9,
+        entity_type="entity_1",
+        values=[{"value": "value_2"}],
+    )
+
+    entity_3 = BaseEntity(
+        range={"from": 0, "to": len(body)},
+        body=body,
+        dim="default",
+        score=0.5,
+        entity_type="entity_1",
+        values=[{"value": "value_3"}],
+    )
+
+    workflow.set("output.intents", [intent]).set(
+        "output.entities", [entity_1, entity_2, entity_3], sort_output_attributes=False
+    ) # we don't want to sort the output attributes here as we want to test if slot.json() does the sorting for us.
+
+    _, output = workflow.run(Input(utterances=body))
+
+    slot_values = output["intents"][0]["slots"][0]["values"]
+    assert all(slot_values[i]["score"] >= slot_values[i+1]["score"] for i in range(len(slot_values) - 1))


### PR DESCRIPTION
The entities filled for a slot should now be ordered in descending order of the entity scores