### PR TITLE
fix: stanza download checks at runtime can be fatal.

### DIFF
--- a/dialogy/plugins/text/list_search_plugin/__init__.py
+++ b/dialogy/plugins/text/list_search_plugin/__init__.py
@@ -90,11 +90,6 @@ class ListSearchPlugin(EntityScoringMixin, Plugin):
         """
         Parameters for Fuzzy Dependency Parser defined below
         """
-
-        # ensuring stanza models are downloaded
-        stanza.download("en")
-        stanza.download("hi")
-
         self.fuzzy_dp_config = fuzzy_dp_config
         self.entity_dict: Dict[Any, Any] = {}
         self.entity_types: Dict[Any, Any] = {}


### PR DESCRIPTION
This PR removes calls to `stanza.download(...)`. These can fatally crash the server without better error handling and shouldn't be part of the plugin.