### PR TITLE
Make new API of copier compatible

### DIFF
--- a/dialogy/cli/project.py
+++ b/dialogy/cli/project.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import shutil
 
-from copier import copy
+from copier import run_auto
 
 import dialogy.constants as const
 
@@ -34,23 +34,14 @@ def manage_project(
     :rtype: NoneType
     """
     # to handle copier vcs associated git template building.
-    if use_master:
-        copy(
-            template,
-            destination_path,
-            vcs_ref="HEAD",
-            pretend=pretend,
-            only_diff=is_update,
-            force=is_update,
-        )
-    else:
-        copy(
-            f"gh:{namespace}/{template}.git",
-            destination_path,
-            only_diff=is_update,
-            pretend=pretend,
-            force=is_update,
-        )
+    source = template if use_master else f"gh:{namespace}/{template}.git"
+    run_auto(
+        src_path=None if is_update else source,
+        dst_path=destination_path,
+        vcs_ref="HEAD",
+        pretend=pretend,
+        overwrite=is_update,
+    )
 
     return None
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1673,7 +1673,7 @@ transformers = ["transformers (>=3.0.0)"]
 
 [[package]]
 name = "stevedore"
-version = "4.0.0"
+version = "4.0.1"
 description = "Manage dynamic plugins for Python applications"
 category = "dev"
 optional = false
@@ -3616,8 +3616,8 @@ stanza = [
     {file = "stanza-1.4.2.tar.gz", hash = "sha256:2f4780ee05e4920392eebef05e1632838e68c98eccc9cc9259f37ab7a00ba700"},
 ]
 stevedore = [
-    {file = "stevedore-4.0.0-py3-none-any.whl", hash = "sha256:87e4d27fe96d0d7e4fc24f0cbe3463baae4ec51e81d95fbe60d2474636e0c7d8"},
-    {file = "stevedore-4.0.0.tar.gz", hash = "sha256:f82cc99a1ff552310d19c379827c2c64dd9f85a38bcd5559db2470161867b786"},
+    {file = "stevedore-4.0.1-py3-none-any.whl", hash = "sha256:01645addb67beff04c7cfcbb0a6af8327d2efc3380b0f034aa316d4576c4d470"},
+    {file = "stevedore-4.0.1.tar.gz", hash = "sha256:9a23111a6e612270c591fd31ff3321c6b5f3d5f3dabb1427317a5ab608fc261a"},
 ]
 thefuzz = [
     {file = "thefuzz-0.19.0-py2.py3-none-any.whl", hash = "sha256:4fcdde8e40f5ca5e8106bc7665181f9598a9c8b18b0a4d38c41a095ba6788972"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dialogy"
-version = "0.9.20"
+version = "0.9.22"
 description = "Dialogy is a library for building and managing SLU applications."
 authors = ["Amresh Venugopal <amresh.venugopal@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Took a middle ground: `dialogy update` will not work with old SLU projects which were created with older versions of dialogy but should work with new projects 