### PR TITLE
Fix amount <> interval clash

### DIFF
--- a/dialogy/types/entity/deserialize/__init__.py
+++ b/dialogy/types/entity/deserialize/__init__.py
@@ -72,9 +72,14 @@ class EntityDeserializer:
                 reference_time=reference_time,
             )
         except KeyError as e:
-            raise ValueError(
-                f"Failed to deserialize {EntityClass} "
-                f"from duckling response: {duckling_entity_dict}. Exception: {e}"
-            ) from e
+            if entity_class_name == "amount-of-money" and (
+                duckling_entity_dict.get("value", {}).get("type") == "interval"
+            ):
+                entity = None
+            else:
+                raise ValueError(
+                    f"Failed to deserialize {EntityClass} "
+                    f"from duckling response: {duckling_entity_dict}. Exception: {e}"
+                ) from e
 
         return entity

--- a/dialogy/types/entity/deserialize/__init__.py
+++ b/dialogy/types/entity/deserialize/__init__.py
@@ -75,6 +75,8 @@ class EntityDeserializer:
             if entity_class_name == "amount-of-money" and (
                 duckling_entity_dict.get("value", {}).get("type") == "interval"
             ):
+                # interval of "amount": fail silently
+                # TODO: create CurrencyIntervalEntity class to handle this if required
                 entity = None
             else:
                 raise ValueError(


### PR DESCRIPTION
Sometimes (randomly?) [this test](https://gitlab.com/skit-ai/slu/application-collections-entity-improvements/-/blob/74f181767f04d638374c102541f7c0b829ff8034/tests/test_controller/test_predict_api.py#L126) on application collections combined is failing and that's resulting in a [failed CI/CD pipeline](https://gitlab.com/skit-ai/slu/application-collections-entity-improvements/-/jobs/3205115543).

This patch currently bypasses the `dim=amount-of-money` and `type=interval` coupling. (amount-of-money [expects](https://github.com/skit-ai/dialogy/blob/24ad1089e3073106ab5458b93ef36b8bd9904f6e/dialogy/types/entity/amount_of_money/__init__.py#L67) type to be `value`, not `interval`).