### PR TITLE
Making constrained time interval work when no `from` key is present

### DIFF
--- a/dialogy/types/entity/time_interval/__init__.py
+++ b/dialogy/types/entity/time_interval/__init__.py
@@ -201,7 +201,8 @@ class TimeIntervalEntity(TimeEntity):
                     }
                 )
             elif to_:
-                datetime_val[const.FROM][const.VALUE] = (
+                from_or_to = const.FROM if from_datetime_val else const.TO
+                datetime_val[from_or_to][const.VALUE] = (
                     datetime.fromisoformat(
                         datetime_val.get(const.TO, {}).get(const.VALUE)
                     )

--- a/dialogy/types/entity/time_interval/__init__.py
+++ b/dialogy/types/entity/time_interval/__init__.py
@@ -203,7 +203,7 @@ class TimeIntervalEntity(TimeEntity):
             elif to_:
                 datetime_val[const.FROM][const.VALUE] = (
                     datetime.fromisoformat(
-                        datetime_val.get(const.FROM, {}).get(const.VALUE)
+                        datetime_val.get(const.TO, {}).get(const.VALUE)
                     )
                     .replace(
                         hour=constraint[const.GTE][const.HOUR],

--- a/dialogy/types/entity/time_interval/__init__.py
+++ b/dialogy/types/entity/time_interval/__init__.py
@@ -202,13 +202,14 @@ class TimeIntervalEntity(TimeEntity):
                 )
             elif to_:
                 from_or_to = const.FROM if from_datetime_val else const.TO
+                gte_or_lte = const.GTE if from_datetime_val else const.LTE
                 datetime_val[from_or_to][const.VALUE] = (
                     datetime.fromisoformat(
-                        datetime_val.get(const.TO, {}).get(const.VALUE)
+                        datetime_val.get(from_or_to, {}).get(const.VALUE)
                     )
                     .replace(
-                        hour=constraint[const.GTE][const.HOUR],
-                        minute=constraint[const.GTE][const.MINUTE],
+                        hour=constraint[gte_or_lte][const.HOUR],
+                        minute=constraint[gte_or_lte][const.MINUTE],
                         second=0,
                         microsecond=0,
                     )


### PR DESCRIPTION
fixes #164 