### PR TITLE
Refactor/state management

### DIFF
--- a/dialogy/base/input/__init__.py
+++ b/dialogy/base/input/__init__.py
@@ -79,12 +79,12 @@ If there is a need to represent an :ref:`Input<Input>` as a `dict` we can do the
 from __future__ import annotations
 
 from functools import reduce
-from typing import Any, Dict, List, Optional, Union, Set
+from typing import Any, Dict, List, Optional, Set, Union
 
 import attr
 
 from dialogy.types import Utterance
-from dialogy.utils import is_unix_ts, normalize, get_best_transcript
+from dialogy.utils import get_best_transcript, is_unix_ts, normalize
 
 
 @attr.frozen

--- a/dialogy/base/plugin/__init__.py
+++ b/dialogy/base/plugin/__init__.py
@@ -243,7 +243,7 @@ class Plugin(ABC):
         self.debug = debug
         self.guards = guards
         self.dest = dest
-        self.buffer = []
+        self.buffer: List[Any] = []
         self.replace_output = replace_output
         self.input_column = input_column
         self.output_column = output_column or input_column
@@ -299,9 +299,10 @@ class Plugin(ABC):
             value = value + self.buffer
             self.commit([])
 
-        workflow.set(self.dest, value)
+        if self.dest:
+            workflow.set(self.dest, value)
 
-    def commit(self, value):
+    def commit(self, value: List[Any]) -> None:
         """
         Set the value of the plugin's buffer.
 

--- a/dialogy/base/plugin/__init__.py
+++ b/dialogy/base/plugin/__init__.py
@@ -243,6 +243,7 @@ class Plugin(ABC):
         self.debug = debug
         self.guards = guards
         self.dest = dest
+        self.buffer = []
         self.replace_output = replace_output
         self.input_column = input_column
         self.output_column = output_column or input_column
@@ -290,8 +291,24 @@ class Plugin(ABC):
             return
 
         value = self.utility(workflow.input, workflow.output)
-        if value is not None and isinstance(self.dest, str):
-            workflow.set(self.dest, value, self.replace_output)
+
+        if value is None:
+            return
+
+        if isinstance(value, list) and self.buffer:
+            value = value + self.buffer
+            self.commit([])
+
+        workflow.set(self.dest, value)
+
+    def commit(self, value):
+        """
+        Set the value of the plugin's buffer.
+
+        :param value: The value to be set.
+        :type value: Any
+        """
+        self.buffer = value
 
     def prevent(self, input_: Input, output: Output) -> bool:
         """

--- a/dialogy/plugins/__init__.py
+++ b/dialogy/plugins/__init__.py
@@ -1,3 +1,4 @@
+from dialogy.plugins.text.address_parser import AddressParserPlugin
 from dialogy.plugins.text.calibration.xgb import CalibrationModel
 from dialogy.plugins.text.canonicalization import CanonicalizationPlugin
 from dialogy.plugins.text.classification.mlp import MLPMultiClass
@@ -5,10 +6,9 @@ from dialogy.plugins.text.classification.retain_intent import RetainOriginalInte
 from dialogy.plugins.text.classification.xlmr import XLMRMultiClass
 from dialogy.plugins.text.combine_date_time import CombineDateTimeOverSlots
 from dialogy.plugins.text.duckling_plugin import DucklingPlugin
+from dialogy.plugins.text.error_recovery.error_recovery import ErrorRecoveryPlugin
 from dialogy.plugins.text.lb_plugin import DucklingPluginLB
 from dialogy.plugins.text.list_entity_plugin import ListEntityPlugin
 from dialogy.plugins.text.list_search_plugin import ListSearchPlugin
 from dialogy.plugins.text.merge_asr_output import MergeASROutputPlugin
 from dialogy.plugins.text.slot_filler.rule_slot_filler import RuleBasedSlotFillerPlugin
-from dialogy.plugins.text.address_parser import AddressParserPlugin
-from dialogy.plugins.text.error_recovery.error_recovery import ErrorRecoveryPlugin

--- a/dialogy/plugins/text/address_parser/__init__.py
+++ b/dialogy/plugins/text/address_parser/__init__.py
@@ -5,14 +5,13 @@ from typing import Any, Callable, Dict, List, Optional
 
 import googlemaps
 
+from dialogy.base.plugin import Input, Output, Plugin
 from dialogy.plugins.text.address_parser import mapmyindia
-from dialogy.base.plugin import Plugin, Input, Output
-from dialogy.types import AddressEntity
-
 from dialogy.plugins.text.address_parser.maps import (
     get_gmaps_address,
     get_mapmyindia_address,
 )
+from dialogy.types import AddressEntity
 
 
 class MissingCredentials(Exception):

--- a/dialogy/plugins/text/address_parser/mapmyindia.py
+++ b/dialogy/plugins/text/address_parser/mapmyindia.py
@@ -1,6 +1,6 @@
-from typing import Dict, Union, Optional
-import requests
+from typing import Dict, Optional, Union
 
+import requests
 from loguru import logger
 
 

--- a/dialogy/plugins/text/address_parser/maps.py
+++ b/dialogy/plugins/text/address_parser/maps.py
@@ -1,6 +1,6 @@
 import re
 import uuid
-from typing import Callable, List, Dict, Any, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import googlemaps
 from loguru import logger

--- a/dialogy/plugins/text/combine_date_time/__init__.py
+++ b/dialogy/plugins/text/combine_date_time/__init__.py
@@ -193,10 +193,11 @@ class CombineDateTimeOverSlots(Plugin):
             lambda entity: entity.entity_type
             in CombineDateTimeOverSlots.SUPPORTED_ENTITIES,
         )
+        self.commit(other_entities)
         combined_time_entities = [
             self.join(entity, previously_filled_time_entity) for entity in time_entities
         ]
-        return combined_time_entities + other_entities
+        return combined_time_entities
 
     def utility(self, input: Input, output: Output) -> List[BaseEntity]:
         """

--- a/dialogy/plugins/text/duckling_plugin/__init__.py
+++ b/dialogy/plugins/text/duckling_plugin/__init__.py
@@ -988,6 +988,7 @@ class DucklingPlugin(EntityScoringMixin, Plugin):
         self.reference_time = input.reference_time
         self.locale = input.locale or self.locale
         use_latent = input.latent_entities
+        self.commit(output.entities)
 
         return self.parse(
             transcripts,

--- a/dialogy/plugins/text/error_recovery/error_recovery.py
+++ b/dialogy/plugins/text/error_recovery/error_recovery.py
@@ -21,13 +21,12 @@ These requirements are met by a mature, feature-rich, battle-tested high level l
 """
 import calendar
 from datetime import timedelta
-from typing import Any, Dict, List, Set, Union, Callable, Iterable, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Union
 
 import attr
 
-from dialogy.base import Input, Output, Plugin, Guard
+from dialogy.base import Guard, Input, Output, Plugin
 from dialogy.types import BaseEntity, Intent, TimeEntity
-
 
 TRemove = Optional[str]
 TUpdate = Optional[Dict[str, Any]]

--- a/dialogy/plugins/text/list_entity_plugin/__init__.py
+++ b/dialogy/plugins/text/list_entity_plugin/__init__.py
@@ -279,8 +279,9 @@ class ListEntityPlugin(EntityScoringMixin, Plugin):
         aggregated_entities = self.entity_consensus(entities, len(transcripts))
         return self.apply_filters(aggregated_entities)
 
-    def utility(self, input: Input, _: Output) -> Any:
-        transcripts = input.transcripts
+    def utility(self, input_: Input, output: Output) -> Any:
+        transcripts = input_.transcripts
+        self.commit(output.entities)
         return self.get_entities(transcripts)  # pylint: disable=no-value-for-parameter
 
     def ner_search(self, transcript: str) -> MatchType:

--- a/dialogy/plugins/text/list_search_plugin/__init__.py
+++ b/dialogy/plugins/text/list_search_plugin/__init__.py
@@ -294,7 +294,8 @@ class ListSearchPlugin(EntityScoringMixin, Plugin):
         aggregated_entities = self.entity_consensus(entities, len(transcripts))
         return self.apply_filters(aggregated_entities)
 
-    def utility(self, input_: Input, _: Output) -> Any:
+    def utility(self, input_: Input, output: Output) -> Any:
+        self.commit(output.entities)
         return self.get_entities(
             input_.transcripts, input_.lang
         )  # pylint: disable=no-value-for-parameter

--- a/dialogy/plugins/text/slot_filler/rule_slot_filler.py
+++ b/dialogy/plugins/text/slot_filler/rule_slot_filler.py
@@ -9,7 +9,7 @@ role. This plugin orchestrates the execution of slot filling via methods availab
 #. Once entities are found, we check if the slots can fill them using the :ref:`fill<FillSlot>` method.
 #. If no slots were filled, we remove the placeholders using :ref:`cleanup<CleanupSlot>` method.
 """
-from typing import List, Union, Set
+from typing import List, Set, Union
 
 from dialogy.base import Guard, Input, Output, Plugin
 from dialogy.types import BaseEntity

--- a/dialogy/utils/__init__.py
+++ b/dialogy/utils/__init__.py
@@ -15,8 +15,8 @@ from dialogy.utils.logger import logger
 from dialogy.utils.misc import traverse_dict, validate_type
 from dialogy.utils.naive_lang_detect import lang_detect_from_text
 from dialogy.utils.normalize_utterance import (
+    get_best_transcript,
     is_utterance,
     normalize,
-    get_best_transcript,
 )
 from dialogy.utils.temperature_scaling import fit_ts_parameter, save_reliability_graph

--- a/dialogy/workflow/workflow.py
+++ b/dialogy/workflow/workflow.py
@@ -216,26 +216,16 @@ class Workflow:
         :return: This instance
         :rtype: Workflow
         """
-        dest, attribute = path.split(".")
+        obj, attribute = path.split(".")
 
-        if dest == const.INPUT:
+        if obj == const.INPUT:
             self.input = Input.from_dict({attribute: value}, reference=self.input)
-        elif attribute in const.OUTPUT_ATTRIBUTES and isinstance(value, (list, dict)):
-            if not replace and isinstance(value, list):
-                previous_value = self.output.intents if attribute == const.INTENTS else self.output.entities  # type: ignore
-                if sort_output_attributes:
-                    value = sorted(
-                        previous_value + value,
-                        key=lambda parse: parse.score or 0,
-                        reverse=True,
-                    )
-                else:
-                    value = previous_value + value
-
+        elif (obj in const.OUTPUT
+                and attribute in (const.INTENTS, const.ENTITIES, const.ORIGINAL_INTENT)
+                and isinstance(value, (list, dict))):
             self.output = Output.from_dict({attribute: value}, reference=self.output)
-
-        elif dest == const.OUTPUT:
-            raise ValueError(f"{value=} should be a List[Intent] or List[BaseEntity].")
+        elif obj == const.OUTPUT:
+            raise ValueError(f"{value=} should be a List[Intent], List[BaseEntity] or a Dict[str, float].")
         else:
             raise ValueError(f"{path} is not a valid path.")
         return self

--- a/dialogy/workflow/workflow.py
+++ b/dialogy/workflow/workflow.py
@@ -220,12 +220,16 @@ class Workflow:
 
         if obj == const.INPUT:
             self.input = Input.from_dict({attribute: value}, reference=self.input)
-        elif (obj in const.OUTPUT
-                and attribute in (const.INTENTS, const.ENTITIES, const.ORIGINAL_INTENT)
-                and isinstance(value, (list, dict))):
+        elif (
+            obj in const.OUTPUT
+            and attribute in (const.INTENTS, const.ENTITIES, const.ORIGINAL_INTENT)
+            and isinstance(value, (list, dict))
+        ):
             self.output = Output.from_dict({attribute: value}, reference=self.output)
         elif obj == const.OUTPUT:
-            raise ValueError(f"{value=} should be a List[Intent], List[BaseEntity] or a Dict[str, float].")
+            raise ValueError(
+                f"{value=} should be a List[Intent], List[BaseEntity] or a Dict[str, float]."
+            )
         else:
             raise ValueError(f"{path} is not a valid path.")
         return self

--- a/tests/plugin/text/address_parser/test_address_parser.py
+++ b/tests/plugin/text/address_parser/test_address_parser.py
@@ -1,20 +1,18 @@
 import collections
 import json
-import requests
 from datetime import timedelta
 
+import googlemaps
 import httpretty
 import pytest
-import googlemaps
+import requests
 
 from dialogy import plugins
 from dialogy.base import Input, Output
 from dialogy.plugins.text.address_parser import MissingCredentials
 from dialogy.plugins.text.address_parser.mapmyindia import MapMyIndia
-from dialogy.types import Intent
+from dialogy.types import AddressEntity, Intent
 from dialogy.workflow import Workflow
-from dialogy import plugins
-from dialogy.types import AddressEntity
 from tests import load_tests
 
 _USER_AGENT = "GoogleGeoApiClientPython/%s" % googlemaps.__version__

--- a/tests/plugin/text/error_recovery/test_error_recovery.py
+++ b/tests/plugin/text/error_recovery/test_error_recovery.py
@@ -3,14 +3,14 @@ from datetime import datetime
 import pytest
 
 from dialogy.base import Input, Output
-from dialogy.workflow import Workflow
-from dialogy.types import Intent
-from dialogy.types.entity.deserialize import EntityDeserializer
 from dialogy.plugins.text.error_recovery.error_recovery import (
-    Rule,
     Environment,
     ErrorRecoveryPlugin,
+    Rule,
 )
+from dialogy.types import Intent
+from dialogy.types.entity.deserialize import EntityDeserializer
+from dialogy.workflow import Workflow
 from tests import load_tests
 
 

--- a/tests/workflow/test_workflow.py
+++ b/tests/workflow/test_workflow.py
@@ -4,7 +4,7 @@ import pytest
 
 import dialogy.constants as const
 from dialogy.base import Input, Output, Plugin
-from dialogy.plugins import MergeASROutputPlugin, ListEntityPlugin
+from dialogy.plugins import ListEntityPlugin, MergeASROutputPlugin
 from dialogy.types import Intent, KeywordEntity
 from dialogy.workflow import Workflow
 
@@ -125,6 +125,7 @@ def test_flush_on_exception():
         assert workflow.output == Output()
         assert workflow.input == None
 
+
 def test_commit_entity():
     plugin = ListEntityPlugin(
         style=const.REGEX,
@@ -134,7 +135,8 @@ def test_commit_entity():
                 "orange": ["orange"],
             },
         },
-        dest="output.entities",)
+        dest="output.entities",
+    )
 
     entity_dict = {
         const.RANGE: {


### PR DESCRIPTION
# Motivation

I was recently documenting the migration effort between dialogy `0.8.x` -> `0.9.x` and I needed to explain the plugin interface. The amount of effort required to explain `replace_output` whilst not reducing risk of it being used incorrectly made me go for this refactor.

# Background

Previously the `workflow` would manage the state for us. If `DucklingPlugin` gave us `TimeEntity` after which we invoked the `ListEntityPlugin` to get say an arbitrary `FoodEntity` then they would both be appended. However if you wanted to filter out entities? How would that work? (as the default append logic fails)

To solve it we had made a `replace_output` argument. If you set this to `True` for your plugin, it would use the plugin's output as the new value for entities instead of appending.

# Update
This PR reverses the default behaviour as filtering entities on arbitrary conditions will be a more common use-case for solutions team. Our product ML team will author entity generating plugins and the difference in the release cycles of these teams makes me confident of this decision. 

Basically: 

1. `workflow` stops being smart about append vs full replacement.
2. Entity generating plugins need to explicitly commit older entities.
3. Entity filtering plugins have an option to retain older entities.

To do that, we have a `plugin.commit` method used the following way.

```python
def utility(i: Input, o: Output) -> List[BaseEntity]:
    self.commit(o.entities)
```
or
```python
def utility(i: Input, o: Output) -> List[BaseEntity]:
    self.commit(filter(lambda e: e.type in {'number'} and e.get_value() < 4, o.entities))
```

