### PR TITLE
[WIP] Thread safety and Coupling between Workflow/Plugin

### DIFF
--- a/dialogy/base/plugin/__init__.py
+++ b/dialogy/base/plugin/__init__.py
@@ -198,15 +198,12 @@ If your plugin belongs to [1], then you need to set :code:`replace_output=True` 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 import dialogy.constants as const
 from dialogy.base.input import Input
 from dialogy.base.output import Output
 from dialogy.utils.logger import logger
-
-if TYPE_CHECKING:  # pragma: no cover
-    from dialogy.workflow import Workflow
 
 
 Guard = Callable[[Input, Output], bool]
@@ -261,7 +258,7 @@ class Plugin(ABC):
         :rtype: Any
         """
 
-    def __call__(self, workflow: Workflow) -> None:
+    def __call__(self, input, output):
         """
         Set workflow with output.
 
@@ -274,24 +271,75 @@ class Plugin(ABC):
         - The workflow takes care of keeping its :ref:`input<Input>` and :ref:`output<Output>` immutable.
 
         .. _PluginBookkeeping:
-
+        
         :param workflow: An instance of :ref:`Workflow <WorkflowClass>`.
         :type workflow: Workflow
         """
         logger.enable(str(self)) if self.debug else logger.disable(str(self))
 
-        if workflow.input is None:
-            return
+        if input is None:
+            return input, output
 
-        if workflow.output is None:
-            return
+        if output is None:
+            return input, output
 
-        if self.prevent(workflow.input, workflow.output):
-            return
+        if self.prevent(input, output):
+            return input, output
 
-        value = self.utility(workflow.input, workflow.output)
+        # compute
+        value = self.utility(input, output)
+
+        # update
         if value is not None and isinstance(self.dest, str):
-            workflow.set(self.dest, value, self.replace_output)
+            input, output = self.set(value, input, output)
+        
+        return input, output
+
+
+    def set(
+        self,
+        value: Any,
+        input, output,
+        sort_output_attributes: bool = True,
+    ):
+        """
+        Set attribute path with value.
+        This method (re)-sets the input or output object without losing information
+        from previous instances.
+        :param path: A '.' separated attribute path.
+        :type path: str
+        :param value: A value to set.
+        :type value: Any
+        :param sort_output_attributes: A boolean to sort output attributes.
+        :type value: bool
+        :return: This instance
+        :rtype: Workflow
+        """
+        dest, attribute = self.dest.split(".")
+
+        if dest == const.INPUT:
+            input = input.copy(update={attribute: value}, deep=True)
+            
+        elif attribute in const.OUTPUT_ATTRIBUTES and isinstance(value, (list, dict)):
+            if not self.replace_output and isinstance(value, list):
+                previous_value = output.intents if attribute == const.INTENTS else output.entities  # type: ignore
+                if sort_output_attributes:
+                    value = sorted(
+                        previous_value + value,
+                        key=lambda parse: parse.score or 0,
+                        reverse=True,
+                    )
+                else:
+                    value = previous_value + value
+
+            output = output.copy(udpate={attribute: value}, deep=True)
+
+        elif dest == const.OUTPUT:
+            raise ValueError(f"{value=} should be a List[Intent] or List[BaseEntity].")
+        else:
+            raise ValueError(f"{self.dest} is not a valid path.")
+            
+        return input, output
 
     def prevent(self, input_: Input, output: Output) -> bool:
         """

--- a/dialogy/workflow/workflow.py
+++ b/dialogy/workflow/workflow.py
@@ -113,10 +113,8 @@ How does it do it?
 """
 from __future__ import annotations
 
-import copy
 import time
-from threading import Lock
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List
 
 import attr
 import pandas as pd
@@ -145,103 +143,32 @@ class Workflow:
     List of :ref:`plugins <AbstractPlugin>`.
     """
 
-    input: Optional[Input] = attr.ib(
-        default=None,
-        kw_only=True,
-        validator=attr.validators.optional(attr.validators.instance_of(Input)),
-    )
-    """
-    Represents the SLU API request object. A few nested properties and intermediates are flattened out
-    for readability.
-    """
-
-    output: Optional[Output] = attr.ib(
-        default=None,
-        kw_only=True,
-        validator=attr.validators.optional(attr.validators.instance_of(Output)),
-    )
-    """
-    Represents the SLU API response object.
-    """
-
     debug = attr.ib(
         type=bool, default=False, validator=attr.validators.instance_of(bool)
     )
     """
     Switch on/off the debug logs for the workflow.
     """
-    lock: Lock
-    """
-    A :ref:`workflow <WorkflowClass>` isn't thread-safe by itself. We need locks
-    to prevent race conditions.
-    """
+
     NON_SERIALIZABLE_FIELDS = [const.PLUGINS, const.DEBUG, const.LOCK]
 
     def __attrs_post_init__(self) -> None:
         """
         Post init hook.
         """
-        self.__reset()
-        self.lock = Lock()
         for plugin in self.plugins:
             if isinstance(plugin, Plugin):
                 plugin.debug = self.debug & plugin.debug
 
-    def __reset(self) -> None:
+    def run(self, input: Input, output: Output):
         """
-        Use this method to keep workflow-io in the same format as expected.
-        """
-        self.input = None
-        self.output = Output()
+        .. _workflow_run:
 
-    def set(
-        self,
-        path: str,
-        value: Any,
-        replace: bool = False,
-        sort_output_attributes: bool = True,
-    ) -> Workflow:
-        """
-        Set attribute path with value.
+        Get final results from the workflow.
 
-        This method (re)-sets the input or output object without losing information
-        from previous instances.
+        The current workflow exhibits the following simple procedure:
+        pre-processing -> inference -> post-processing.
 
-        :param path: A '.' separated attribute path.
-        :type path: str
-        :param value: A value to set.
-        :type value: Any
-        :param sort_output_attributes: A boolean to sort output attributes.
-        :type value: bool
-        :return: This instance
-        :rtype: Workflow
-        """
-        dest, attribute = path.split(".")
-
-        if dest == const.INPUT:
-            self.input = Input.from_dict({attribute: value}, reference=self.input)
-        elif attribute in const.OUTPUT_ATTRIBUTES and isinstance(value, (list, dict)):
-            if not replace and isinstance(value, list):
-                previous_value = self.output.intents if attribute == const.INTENTS else self.output.entities  # type: ignore
-                if sort_output_attributes:
-                    value = sorted(
-                        previous_value + value,
-                        key=lambda parse: parse.score or 0,
-                        reverse=True,
-                    )
-                else:
-                    value = previous_value + value
-
-            self.output = Output.from_dict({attribute: value}, reference=self.output)
-
-        elif dest == const.OUTPUT:
-            raise ValueError(f"{value=} should be a List[Intent] or List[BaseEntity].")
-        else:
-            raise ValueError(f"{path} is not a valid path.")
-        return self
-
-    def execute(self) -> Workflow:
-        """
         Update input, output attributes.
 
         We iterate through pre/post processing functions and update the input and
@@ -258,62 +185,27 @@ class Workflow:
                 history = {
                     "plugin": plugin,
                     "before": {
-                        "input": self.input,
-                        "output": self.output,
+                        "input": input,
+                        "output": output,
                     },
                 }
+
             start = time.perf_counter()
-            plugin(self)
+            input, output = plugin(input, output)
             end = time.perf_counter()
+
             # logs are available only when debug=False during class initialization
             if self.debug:
                 history["after"] = {
-                    "input": self.input,
-                    "output": self.output,
+                    "input": input,
+                    "output": output,
                 }
                 history["perf"] = round(end - start, 4)
+
             if history:
                 logger.debug(history)
-        return self
 
-    def run(self, input_: Input) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """
-        .. _workflow_run:
-
-        Get final results from the workflow.
-
-        The current workflow exhibits the following simple procedure:
-        pre-processing -> inference -> post-processing.
-        """
-        with self.lock:
-            self.input = input_
-            try:
-                return self.execute().flush()
-            finally:
-                self.__reset()
-
-    def flush(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """
-        Reset :code:`workflow.input` and :code:`workflow.output`.
-        """
-        if self.input is None or self.output is None:
-            return {}, {}
-        input_ = copy.deepcopy(self.input.json())
-        output = copy.deepcopy(self.output.json())
-        self.__reset()
-        return input_, output
-
-    def json(self) -> Dict[str, Any]:
-        """
-        Represent the workflow as a python dict.
-
-        :rtype: Dict[str, Any]
-        """
-        return attr.asdict(
-            self,
-            filter=lambda attribute, _: attribute.name
-            not in self.NON_SERIALIZABLE_FIELDS,
-        )
+        return input, output
 
     def train(self, training_data: pd.DataFrame) -> Workflow:
         """
@@ -332,6 +224,3 @@ class Workflow:
             if transformed_data is not None:
                 training_data = transformed_data
         return self
-
-
-47


### PR DESCRIPTION
## Changes [WIP]

### 1. Thread Safety

SLU Service/API generally has a single `Workflow` object in memory that is responsible for execution of plugins across all requests and maintaining their respective state (input/output) variables. While that in itself is not problematic, `Workflow` is writing to shared state variables. Since it also has to accommodate requests from concurrent threads, it is doing so with the help of a synchronisation primitive `lock` order to prevent a race condition. Thread safety in this context is a solution to a problem we invented.

Additionally, `Workflow` implements `reset` and `flush` auxiliary functions for maintaining state variables.

This MR removes the original problem i.e. writing to shared state variables and strips all the bloat needed for synchronisation. 

### 2. Coupling between Workflow/Plugin

There is tight control and data coupling between `Workflow` and `Plugin`. This is most evident in `set` function implemented by Workflow that syncs the output of a plugin with the internal state variables thereby compensating for the input/output asymmetry of a plugin `utility` function. However, `set` is called from a plugin base method `__call__`. Since change 1 moves internal state variables out of Workflow, Plugin no longer has to depend on it to maintain symmetry.

This MR moves the `set` function to `Plugin` and reduces it's coupling with `Workflow`.