### PR TITLE
CSLU config and XLMR regression test fix CMS-2896

### DIFF
--- a/dialogy/plugins/text/classification/xlmr.py
+++ b/dialogy/plugins/text/classification/xlmr.py
@@ -94,7 +94,7 @@ class XLMRMultiClass(Plugin):
 
         self.ts_parameter: float = read_from_json([const.TS_PARAMETER], self.model_dir,
                                                   const.CALIBRATION_CONFIG_FILE).get(
-            const.TS_PARAMETER) or self.args_map.get("ts_parameter") or 1.0
+            const.TS_PARAMETER) or self.args_map.get(const.TS_PARAMETER) or 1.0
 
         # flag that specifies whether plugin is being imported externally solely for model
         imported = kwargs.get("imported", False)

--- a/dialogy/plugins/text/classification/xlmr.py
+++ b/dialogy/plugins/text/classification/xlmr.py
@@ -111,7 +111,7 @@ class XLMRMultiClass(Plugin):
                     f"'best_model_dir' missing in passed args_map."
                 )
             
-            self.ts_parameter:float = self.args_map.get("ts_parameter") or read_from_json([const.TS_PARAMETER], self.model_dir, const.CALIBRATION_CONFIG_FILE).get(const.TS_PARAMETER) or 1.0
+            self.ts_parameter:float = read_from_json([const.TS_PARAMETER], self.model_dir, const.CALIBRATION_CONFIG_FILE).get(const.TS_PARAMETER) or self.args_map.get("ts_parameter") or 1.0
             
             self.labelencoder = preprocessing.LabelEncoder()
             self.classifier = classifer

--- a/dialogy/plugins/text/classification/xlmr.py
+++ b/dialogy/plugins/text/classification/xlmr.py
@@ -90,6 +90,11 @@ class XLMRMultiClass(Plugin):
 
         self.use_calibration = self.args_map.get(const.MODEL_CALIBRATION, False)
 
+        self.model_dir = self.args_map.get("best_model_dir")
+
+        self.ts_parameter: float = read_from_json([const.TS_PARAMETER], self.model_dir,
+                                                  const.CALIBRATION_CONFIG_FILE).get(
+            const.TS_PARAMETER) or self.args_map.get("ts_parameter") or 1.0
 
         # flag that specifies whether plugin is being imported externally solely for model
         imported = kwargs.get("imported", False)
@@ -105,14 +110,11 @@ class XLMRMultiClass(Plugin):
                     "Plugin requires simpletransformers -- https://simpletransformers.ai/docs/installation/"
                 ) from error
 
-            self.model_dir = self.args_map.get("best_model_dir")
             if not self.model_dir:
                 raise ValueError(
                     f"'best_model_dir' missing in passed args_map."
                 )
-            
-            self.ts_parameter:float = read_from_json([const.TS_PARAMETER], self.model_dir, const.CALIBRATION_CONFIG_FILE).get(const.TS_PARAMETER) or self.args_map.get("ts_parameter") or 1.0
-            
+
             self.labelencoder = preprocessing.LabelEncoder()
             self.classifier = classifer
             self.model: Any = None

--- a/dialogy/plugins/text/classification/xlmr.py
+++ b/dialogy/plugins/text/classification/xlmr.py
@@ -90,6 +90,7 @@ class XLMRMultiClass(Plugin):
 
         self.use_calibration = self.args_map.get(const.MODEL_CALIBRATION, False)
 
+
         # flag that specifies whether plugin is being imported externally solely for model
         imported = kwargs.get("imported", False)
 
@@ -97,8 +98,7 @@ class XLMRMultiClass(Plugin):
             self.use_cuda = torch.cuda.is_available()
             try:
                 classifer = getattr(
-                    importlib.import_module(const.XLMR_MODULE),
-                    const.XLMR_MULTI_CLASS_MODEL,
+                    importlib.import_module(const.XLMR_MODULE), const.XLMR_MULTI_CLASS_MODEL
                 )
             except ModuleNotFoundError as error:
                 raise ModuleNotFoundError(
@@ -107,8 +107,10 @@ class XLMRMultiClass(Plugin):
 
             self.model_dir = self.args_map.get("best_model_dir")
             if not self.model_dir:
-                raise ValueError(f"'best_model_dir' missing in passed args_map.")
-
+                raise ValueError(
+                    f"'best_model_dir' missing in passed args_map."
+                )
+            
             self.ts_parameter: float = (
                 read_from_json(
                     [const.TS_PARAMETER], self.model_dir, const.CALIBRATION_CONFIG_FILE
@@ -116,7 +118,6 @@ class XLMRMultiClass(Plugin):
                 or self.args_map.get("ts_parameter")
                 or 1.0
             )
-
             self.labelencoder = preprocessing.LabelEncoder()
             self.classifier = classifer
             self.model: Any = None
@@ -135,9 +136,7 @@ class XLMRMultiClass(Plugin):
 
             try:
                 if os.path.exists(self.labelencoder_file_path):
-                    logger.debug(
-                        f"initializing label encoder file from {self.labelencoder_file_path}"
-                    )
+                    logger.debug(f"initializing label encoder file from {self.labelencoder_file_path}")
                     self.init_model()
             except EOFError:
                 logger.error(
@@ -150,7 +149,9 @@ class XLMRMultiClass(Plugin):
             # model inference service session configuration
             self.url = url
             self.timeout = timeout
-            self.headers: Dict[str, str] = {"Content-Type": "application/json"}
+            self.headers: Dict[str, str] = {
+                "Content-Type": "application/json"
+            }
 
         self.debug = debug
 
@@ -181,10 +182,8 @@ class XLMRMultiClass(Plugin):
                 **self.kwargs,
             )
         except OSError:
-            logger.info(
-                f"Model not found at {self.model_dir}. "
-                f"Default model weights will be loaded"
-            )
+            logger.info(f"Model not found at {self.model_dir}. "
+                        f"Default model weights will be loaded")
             self.model = self.classifier(
                 const.XLMR_MODEL,
                 const.XLMR_MODEL_TIER,
@@ -202,9 +201,7 @@ class XLMRMultiClass(Plugin):
         payload = {"transcripts": texts}
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    self.url, data=json.dumps(payload), headers=self.headers
-                ) as resp:
+                async with session.post(self.url, data=json.dumps(payload), headers=self.headers) as resp:
                     status_code = resp.status
                     if status_code == 200:
                         result = await resp.json()
@@ -229,6 +226,7 @@ class XLMRMultiClass(Plugin):
         lang: Optional[str] = None,
         nls_label: Optional[str] = None,
     ) -> List[Intent]:
+
         """
         Predict the intent of a list of texts.
         If the model has been trained using the state features, it expects the text to also be appended with the state token else the predictions would be spurious.
@@ -285,11 +283,9 @@ class XLMRMultiClass(Plugin):
                 return [fallback_output]
 
         else:
-            raise RuntimeError(
-                f"Inference method called with purpose "
-                f"set to '{self.purpose}'. Valid "
-                f"values - [{const.PRODUCTION}, {const.TEST}]"
-            )
+            raise RuntimeError(f"Inference method called with purpose "
+                               f"set to '{self.purpose}'. Valid "
+                               f"values - [{const.PRODUCTION}, {const.TEST}]")
 
         logits = logits / self.ts_parameter
         confidence_scores = [np.exp(logit) / sum(np.exp(logit)) for logit in logits]
@@ -341,7 +337,7 @@ class XLMRMultiClass(Plugin):
                 logger.warning(f"Column {column} not found in training data")
                 return False
         return True
-
+    
     def train(self, training_data: pd.DataFrame) -> None:
         """
         Train an intent-classifier on the provided training data.
@@ -425,7 +421,7 @@ class XLMRMultiClass(Plugin):
                 logger.debug(e)
                 logger.debug(f"Prompt not found for Lang: {lang} \t State: {nls_label}")
             return self.null_prompt_token
-
+        
     def load(self) -> None:
         """
         Load the plugin artifacts.

--- a/dialogy/plugins/text/classification/xlmr.py
+++ b/dialogy/plugins/text/classification/xlmr.py
@@ -111,13 +111,8 @@ class XLMRMultiClass(Plugin):
                     f"'best_model_dir' missing in passed args_map."
                 )
             
-            self.ts_parameter: float = (
-                read_from_json(
-                    [const.TS_PARAMETER], self.model_dir, const.CALIBRATION_CONFIG_FILE
-                ).get(const.TS_PARAMETER)
-                or self.args_map.get("ts_parameter")
-                or 1.0
-            )
+            self.ts_parameter:float = self.args_map.get("ts_parameter") or read_from_json([const.TS_PARAMETER], self.model_dir, const.CALIBRATION_CONFIG_FILE).get(const.TS_PARAMETER) or 1.0
+            
             self.labelencoder = preprocessing.LabelEncoder()
             self.classifier = classifer
             self.model: Any = None

--- a/dialogy/utils/config.py
+++ b/dialogy/utils/config.py
@@ -175,6 +175,12 @@ class Config(BaseConfig):
 
     def get_dataset_dir(self, task_name: str) -> str:
         return os.path.join(self.project_artifacts_root_path, self._get_data_dir(task_name), const.DATASETS)
+    
+    def get_model_dir(self, task_name: str) -> str:
+        return os.path.join(
+            self.project_artifacts_root_path,
+            self.model_config.get_model_dir(task_name)
+        )
 
     def get_skip_list(self, task_name: str) -> Set[str]:
         if task_name == const.CLASSIFICATION:


### PR DESCRIPTION
Fixed two bugs identified.

The `model_config` path is now created properly.
Fixed the failing regression test that was not reading the `ts_config` parameter