### PR TITLE
QC Plugin: Remove handling of triple quoted transcripts

### DIFF
--- a/dialogy/plugins/text/qc_plugin/__init__.py
+++ b/dialogy/plugins/text/qc_plugin/__init__.py
@@ -53,9 +53,6 @@ class QCPlugin(Plugin):
 
         logger.debug(f"Finding data points with conflicting labels...")
 
-        training_data["alternatives"] = training_data["alternatives"].apply(
-            lambda x: x.replace("""\"\"""", """\"""") if isinstance(x, str) else x
-        )
         training_data["frozen_set_hash"] = training_data["alternatives"].apply(
             lambda x: hashlib.md5(
                 pickle.dumps(

--- a/tests/plugin/text/test_qc_plugin/test_qc_plugin.py
+++ b/tests/plugin/text/test_qc_plugin/test_qc_plugin.py
@@ -40,16 +40,6 @@ from dialogy.plugins.registry import QCPlugin
             True,
             2,
         ),
-        (
-            [
-                '[[{"transcript": "hello"}]]',
-                '[[{"transcript": "hello"}]]',
-                """[[{\""confidence\"": 0.801317, \""transcript"" :\""hello\""}]]""",
-            ],
-            ["x1", "x2", "x3"],
-            True,
-            3,
-        ),
     ],
 )
 async def test_drop_conflicting_labels(alternatives, tags, drop, discard_size, tmp_path) -> None:


### PR DESCRIPTION
This line of code did not work well with handling empty transcripts and was a breaking bug.